### PR TITLE
Removed whitespace in image id

### DIFF
--- a/profiles/centosamazon.go
+++ b/profiles/centosamazon.go
@@ -86,7 +86,7 @@ func CentosAmazonCluster(name string) *cluster.Cluster {
 				Name:     fmt.Sprintf("%s.node", name),
 				MaxCount: 1,
 				MinCount: 1,
-				Image:    "ami-0c2aba6c ",
+				Image:    "ami-0c2aba6c",
 				Size:     "t2.medium",
 				BootstrapScripts: []string{
 					"amazon_k8s_centos_7_node.sh",


### PR DESCRIPTION
It's not possible to create k8s cluster because of whitespace in image id:

```
2017-08-15T13:45:21+02:00 [✖]  Error during apply! Attempting cleaning: ValidationError: AMI ami-0c2aba6c  is invalid: Invalid id: "ami-0c2aba6c "
	status code: 400, request id: 378bd487-81af-11e7-b83d-f1bc3586d1ac

```